### PR TITLE
Include new format of error response

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -183,25 +183,50 @@ so we can send the design for manufacture.
 + Response 400 (application/json)
 
         {
-            "detail": "JSON parse error"
+            "code": "bad_request",
+            "message": "Request payload is not valid."
         }
 
 + Response 401 (application/json)
 
         {
-            "detail": "Authentication credentials were not provided."
+            "code": "authentication_failed",
+            "message": "Incorrect authentication credentials."
         }
 
-+ Response 401 (application/json)
++ Response 403 (application/json)
 
         {
-            "detail": "Invalid token."
+            "code": "permission_denied",
+            "message": "You do not have permission to perform this action."
+        }
+
++ Response 404 (application/json)
+
+        {
+            "code": "not_found",
+            "message": "Not found."
         }
 
 + Response 405 (application/json)
 
         {
-            "detail": "Unsupported media type \"type_sent\" in request."
+            "code": "method_not_allowed",
+            "message": "Method used is not allowed"
+        }
+
++ Response 406 (application/json)
+
+        {
+            "code": "not_acceptable",
+            "message": "Could not satisfy the request Accept header."
+        }
+
++ Response 415 (application/json)
+
+        {
+            "code": "unsupported_media_type",
+            "message": "Unsupported media type in request."
         }
 
 + Request Team wear order (application/json)
@@ -273,25 +298,50 @@ so we can send the design for manufacture.
 + Response 400 (application/json)
 
         {
-            "detail": "JSON parse error"
+            "code": "bad_request",
+            "message": "Request payload is not valid."
         }
 
 + Response 401 (application/json)
 
         {
-            "detail": "Authentication credentials were not provided."
+            "code": "authentication_failed",
+            "message": "Incorrect authentication credentials."
         }
 
-+ Response 401 (application/json)
++ Response 403 (application/json)
 
         {
-            "detail": "Invalid token."
+            "code": "permission_denied",
+            "message": "You do not have permission to perform this action."
+        }
+
++ Response 404 (application/json)
+
+        {
+            "code": "not_found",
+            "message": "Not found."
         }
 
 + Response 405 (application/json)
 
         {
-            "detail": "Unsupported media type \"type_sent\" in request."
+            "code": "method_not_allowed",
+            "message": "Method used is not allowed"
+        }
+
++ Response 406 (application/json)
+
+        {
+            "code": "not_acceptable",
+            "message": "Could not satisfy the request Accept header."
+        }
+
++ Response 415 (application/json)
+
+        {
+            "code": "unsupported_media_type",
+            "message": "Unsupported media type in request."
         }
 
 ## Order [/v1/orders/{order_id}/]


### PR DESCRIPTION
### Trello
https://trello.com/c/YCp4Ymwt/63-public-api-response-errors

### Why
We decided that the public facing API will have a more standard way of error response. Being the JSON structure `code` and `message` for the moment.

Also left out `429` and `500`, as I think they are not applicable. Some of 500 cases will raised before even hitting the DRF

### What
Add the response examples