### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.apib]
+indent_style = space
+indent_size = 4

--- a/apiary.apib
+++ b/apiary.apib
@@ -913,19 +913,20 @@ asynchronously once the job is created.
             "id": "a06f2da7-2a65-44ef-bfb6-81dea3f4dfeb",
                 "reference": "partner_order_reference",
                 "jobs": [
-                {
-                    "id": "fa81340e-e2a3-41ae-bd9a-f4dc01122fac",
-                    "reference": "partner_order_reference",
-                    "partner_order_reference": "partner_order_reference",
-                    "partner_item_reference": "partner_order_item_1_reference",
-                    "previews": [
                     {
-                        "name": "Main",
-                        "image": "https://d1joez6ls07j0w.cloudfront.net/job_previews/FA81340E.png"
+                        "id": "fa81340e-e2a3-41ae-bd9a-f4dc01122fac",
+                        "reference": "partner_order_reference",
+                        "partner_order_reference": "partner_order_reference",
+                        "partner_item_reference": "partner_order_item_1_reference",
+                        "previews": [
+                            {
+                                "name": "Main",
+                                "image": "https://d1joez6ls07j0w.cloudfront.net/job_previews/FA81340E.png"
+                            }
+                        ],
+                        job_ticket: "https://nbteam.embed.unmade.com/v1/factories/new-balance-teamwear/jobs/fa81340e-e2a3-41ae-bd9a-f4dc01122fac/job_ticket/",
+                        manufacture_files: "https://nbteam.embed.unmade.com/v1/factories/new-balance-teamwear/jobs/fa81340e-e2a3-41ae-bd9a-f4dc01122fac/manufacture_files/"
                     }
-                    ],
-                    job_ticket	"https://nbteam.embed.unmade.com/v1/factories/new-balance-teamwear/jobs/fa81340e-e2a3-41ae-bd9a-f4dc01122fac/job_ticket/"
-                    manufacture_files	"https://nbteam.embed.unmade.com/v1/factories/new-balance-teamwear/jobs/fa81340e-e2a3-41ae-bd9a-f4dc01122fac/manufacture_files/"                }
                 ]
         }
 


### PR DESCRIPTION
This is because the use of tabs is restricted for .apib files:

https://github.com/unmadeworks/api-docs/commit/9fb90c3028ae81f8795aa6ef0c1eb7e2d8026ba3#commitcomment-39839362

The .editorconfig file isn't enough, but it may help, the problem with tabs was when I copy pasted a response, it was even invalid, so I fixed it here too.