### PR TITLE
Document error responses for the roster API

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -522,7 +522,14 @@ fields selected for a design (I.e. *player-name*, *player-number*, *team-name*).
 Once a user on your platform saves a design with roster data selected, this can be used to create 
 a new design using the roster endpoint. The roster field ids that have been retrieved when getting 
 the design will be used when creating the request. Data that the user has entered for each of them
-must be mapped to each roster field id. 
+must be mapped to each roster field id.
+
+The text sent with each roster field id will be validated to ensure it does not
+contain an illegal characters and also to make sure that, once rendered in the
+chosen font, it is not to wide for the placement. If there are validation
+errors we return a 401 response detailing the codes for the validation errors
+for each field. Possible validation error codes are `illegal_character`,
+`text_too_wide`.
 
 ### Create a roster design [POST]
 #### Roster field rules
@@ -543,7 +550,8 @@ For a roster design to be create the following fields will need to be present:
 
             {
                 "roster_member": {
-                    "player-surname": "<Surname user has entered for this field>"
+                    "last-name": "<Surname user has entered for this field>",
+                    "number": "<Number user has entered for this field>"
                 },
                 
             }
@@ -552,6 +560,25 @@ For a roster design to be create the following fields will need to be present:
 
         {
             "c9b86945-45a6-4a43-beaf-361a7f0d8a77"
+        }
+
+
++ Response 401 (application/json)
+
+        {
+            "code": "bad_request",
+            "message": "Request payload is not valid.",
+            "detail": {
+                "last-name": [
+                    "text_too_wide", “illegal_characters”
+                ],
+                "number": [
+                    "textTooWide", “illegalCharacters”
+                ]
+            },
+            "original_request": {
+                // Body of original request
+            }
         }
 
 


### PR DESCRIPTION
So that our customers know what to expect.

This is a draft PR because this documents how the API may work after the changes I have recommended making to make the API better follow our conventions AND be able to share multiple validation errors in a single response, see https://docs.google.com/document/d/1XjPDrzQ1Dz-bg5TBfeWMEgnt1rFMIT65E160TJQKgsY/edit?usp=sharing for more details

**Outstanding Question:** Are there any other possible error messages for fields? @gingerchris [says that there will be an error message related to text from a field being blocked by our profanity filter](https://unmade.slack.com/archives/CPV368W3Y/p1595914726001200), so, @pssuils, we will need to include this in the documentation too.