### PR TITLE
Correct roster response

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -823,9 +823,7 @@ values for all roster fields in the template roster design is provided:
 
     + Body
 
-            {
-                "c9b86945-45a6-4a43-beaf-361a7f0d8a77"
-            }
+            "c9b86945-45a6-4a43-beaf-361a7f0d8a77"
 
 
 + Response 400 (application/json)


### PR DESCRIPTION
There's no curly brackets or whitespace in the actual response, this may be confusing decathlon.