### PR TITLE
Improve readability for LLMs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           docker compose up render-v2
           mv v2.html docs
+      - name: Copy raw specs and llms.txt
+        run: cp apiary.apib apiary_v2.apib llms.txt docs/
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is an API documentation repository for Unmade's public partner integration API. Documentation is written in [API Blueprint](https://apiblueprint.org/) format (`.apib` files) and rendered to HTML using the [Blueprinter](https://github.com/funbox/blueprinter) Docker image.
+
+## Local Development
+
+Requires Docker. Serves with live-reload at http://localhost:3000/
+
+```bash
+# V1 API docs
+docker-compose up dev
+
+# V2 API docs
+docker-compose up dev-v2
+```
+
+## Building
+
+```bash
+# Generate index.html from V1 spec
+docker-compose up render
+
+# Generate v2.html from V2 spec
+docker-compose up render-v2
+```
+
+## Deployment
+
+Pushing to `main` triggers a GitHub Actions workflow (`.github/workflows/deploy.yml`) that builds both V1 and V2 docs and deploys to GitHub Pages at https://engineering.unmade.com/api-docs/
+
+## Architecture
+
+### Files
+
+- `apiary.apib` — V1 API specification
+- `apiary_v2.apib` — V2 API specification (superset of V1, all endpoints at `/v2/`)
+
+### API Blueprint Format
+
+```
+FORMAT: 1A
+HOST: https://partner-subdomain.embed.unmade.com/
+
+# Group Name
+
+## Endpoint Name [/v2/path/{id}]
+
+### Action Description [GET]
+
++ Request (application/json)
+    + Headers
+            Authorization: Token ABCDEF
+    + Body
+
+            { "field": "value" }
+
++ Response 200 (application/json)
+    + Body
+
+            { "response": "data" }
+```
+
+Indentation in `.apib` files uses 4 spaces (enforced by `.editorconfig`).
+
+### API Versions
+
+**V1** covers: Editor iframe integration, Design API, Transfer Preview API, Roster API, Orders API, Factory API.
+
+**V2** adds/changes: 3D design view (`/v2/designs/{id}/3d/`), partner data endpoints on orders, shipping address retrieval, order items pagination, enhanced job states, and materials data.
+
+### Internal Links
+
+Use relative URLs for internal links between sections (not absolute `#anchor` links), as established in recent commits.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,48 @@
+# Unmade Integration Reference
+
+> Unmade OS is a platform for configurable/customisable product e-commerce. This documentation describes the partner integration API used to embed the Unmade Editor, manage designs, and process orders.
+
+## API Versions
+
+- [V1 API Reference](https://engineering.unmade.com/api-docs/) — HTML rendered docs
+- [V2 API Reference](https://engineering.unmade.com/api-docs/v2.html) — HTML rendered docs
+- [V1 API Blueprint spec](https://engineering.unmade.com/api-docs/apiary.apib) — raw API Blueprint source
+- [V2 API Blueprint spec](https://engineering.unmade.com/api-docs/apiary_v2.apib) — raw API Blueprint source (superset of V1, all endpoints at `/v2/`)
+
+## Authentication
+
+All API endpoints use Token Authentication. Include your token in the `Authorization` header:
+
+```
+Authorization: Token ABC123123
+```
+
+Tokens are provided by Unmade. All API URLs are partner-specific subdomains:
+`https://{your-partner-subdomain}.embed.unmade.com/`
+
+## V1 API Groups
+
+Should only be used for historical context or debugging existing implementations. If adding new functionality to existing projects using V1, consider migrating all usage to equivalent V2 calls. New projects should use V2.
+
+- **Integrating with Unmade** — Overview of the 4-step integration (product setup, editor embed, design ID capture, order creation)
+- **API Setup** — Authentication, subdomains, and general configuration
+- **Unmade Editor** — Embedding the iframe-based design editor into product detail pages
+- **JS Post Messaging Interactions** — Browser postMessage events between the editor iframe and the host page
+- **Transfer Preview API** — Retrieve rendered preview images of a customer's design
+- **Roster API** — Create designs programmatically from variable data using a base design
+- **Orders API** — Create orders, retrieve order status and production state, get tracking numbers
+- **Factory API** — Download manufacturing data for factories
+
+## V2 API Changes
+
+Should be used for any new implementations. 
+
+V2 adds or enhances the following over V1 (all endpoints prefixed `/v2/`):
+
+- 3D design view endpoint (`/v2/designs/{id}/3d/`)
+- Partner data fields on orders
+- Shipping address retrieval
+- Order items pagination
+- Enhanced job states
+- Materials data on jobs
+- Ecommerce Orders API (replaces Orders API)


### PR DESCRIPTION
Publishing the apib markdown files to the docs folder so they are accessible to LLMs. Also providing a llms.txt file so to allow LLMs to discover the docs